### PR TITLE
Add register cls and zookeeper register method

### DIFF
--- a/gunicorn_thrift/config.py
+++ b/gunicorn_thrift/config.py
@@ -128,3 +128,27 @@ class ServiceRegisterClass(Setting):
     desc = """\
         The class used for register service
     """
+
+class ThriftOnExit(Setting):
+    name = "on_exit"
+    section = "Server Hooks"
+    validator = validate_callable(1)
+
+    def on_exit(server):
+        service_watcher = server.app.service_watcher
+        if service_watcher:
+            instances = []
+            for i in server.cfg.address:
+                port = i[1]
+                instances.append({'port': {"main": port},
+                                  'meta': None,
+                                  'state': 'up'})
+            service_watcher.remove_instance(instances)
+
+    default = staticmethod(on_exit)
+    desc = """\
+        Override the original OnExit.
+        Rewrite the on_exit method to remove instances if the app has registered.
+
+    """
+

--- a/gunicorn_thrift/register.py
+++ b/gunicorn_thrift/register.py
@@ -1,0 +1,109 @@
+# -*- coding: utf-8 -*-
+
+import sys
+
+from kazoo.client import KazooClient
+from kazoo.client import KazooState
+from kazoo.exceptions import *
+
+from .utils import get_IPv4
+
+REGISTER_PARAM = ["auth", "addr", "path"]
+
+class Register(object):
+    """
+    Base class of register
+    """
+    def __init__(self, conf, app):
+        self.conf = conf
+        self.app = app
+        self.settings = {}
+
+    def setup(self):
+        pass
+
+    def __getattr__(self, name):
+        if name not in self.settings:
+            raise AttributeError("No configuration setting for: %s" % name)
+        return self.settings[name]
+
+
+    def set(self, name, value):
+        if name not in REGISTER_PARAM:
+            raise AttributeError("No configuration setting for: %s" % name)
+        self.settings[name] = value
+
+
+    def parse_conf(self):
+        for k, v in self.conf.items():
+            if k not in REGISTER_PARAM:
+                continue
+            try:
+                self.set(k.lower(), v)
+            except:
+                print "Invalid value for %s: %s\n" % (k, v)
+                sys.stderr.flush()
+                raise
+
+
+class ZookeeperRegister(Register):
+
+    def __init__(self, conf, app):
+        super(ZookeeperRegister, self).__init__(conf, app)
+        self.parse_conf()
+        self.setup()
+
+    def setup(self):
+        zk = KazooClient(hosts=self.addr)
+        zk.start()
+        self.zk = zk
+        cfg = self.app.cfg
+        log = cfg.logger_class(cfg)
+        self.log = log
+
+    def get_node_path(self, regPath, host, port):
+        addr = host + ':' + str(port)
+        node_path = '/'.join([regPath, addr])
+        return node_path
+
+    def get_node_data(self):
+        '''
+        Return your node data
+        '''
+        node_data = self.path
+        return node_data
+
+    def register_instances(self, instances):
+        if not instances:
+            return
+        ip = get_IPv4('eth0')
+        for instance in instances:
+            port = instance['port']['main']
+            try:
+                node_path = self.get_node_path(self.path, ip, port)
+                node_data = self.get_node_data()
+                self.zk.create(node_path, node_data, ephemeral=True)
+                self.log.info('Success register instance %s' % node_path)
+            except NodeExistsError, e:
+                self.log.error('ZNode Exists Error in Create: ' + str(e))
+            except Exception as e:
+                self.log.error('Unexcept Error: ' + str(e))
+
+    def remove_instance(self, instances):
+        if not instances:
+            return
+        ip = get_IPv4('eth0')
+        for instance in instances:
+            port = instance['port']['main']
+            try:
+                node_path = self.get_node_path(self.path, ip, port)
+                self.zk.delete(node_path, recursive=True)
+                self.log.info('Success remove instance %s' % node_path )
+            except NoNodeError, e:
+                self.log.error('No Node Error in remove: ' + str(e))
+            except Exception as e:
+                self.log.error('Unexcept Error: ' + str(e))
+
+
+
+

--- a/gunicorn_thrift/utils.py
+++ b/gunicorn_thrift/utils.py
@@ -4,6 +4,20 @@ import os
 import importlib
 from gunicorn.errors import AppImportError
 
+import socket
+import struct
+import fcntl
+
+
+def get_IPv4(ethname):
+    s=socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    ip = socket.inet_ntoa(fcntl.ioctl(
+        s.fileno(),
+        0X8915,
+        struct.pack('256s', ethname[:15])
+        )[20:24])
+    return ip
+
 
 def load_obj(import_path):
     parts = import_path.split(":", 1)

--- a/requirements_py27.txt
+++ b/requirements_py27.txt
@@ -4,3 +4,4 @@ gunicorn==19.3.0
 wsgiref==0.1.2
 thrift>=0.9.0
 thriftpy>=0.1.10
+kazoo==2.2.1


### PR DESCRIPTION
@wooparadog 
你好，求review一下代码，
主要内容就是根据ServiceRegisterClass和ServiceRegisterConf，自己写了一个注册的基类Register，然后实现了向zookeeper注册的功能代码。
新重写了ThriftOnExit配置类，其实覆盖了原有的OnExit类，在on_exit方法中加进去了删除注册地址的动作。因为我看gunicorn源码里面的清理动作都是在halt里面进行的，halt最后调用on_exit进行退出前的行为。也可以不加入这部分代码，我们在zookeeper注册的节点都是临时的，程序退出时会自动清理，但是会有时间延迟，不主动清理的话怕会对thrift客户端产生影响。

有些问题需要讨论一下：
目前的注册机制是在application.run()之前，这样会不会有问题，如果run没有起来，但是已经发生注册了，这样thrift客户端有可能获取到一个未成功运行的端口。
为什么不在config里面的when_ready去执行注册的动作呢？
