### PR TITLE
Add on_tdecode_exception hook to catch decode/encode exceptions

### DIFF
--- a/gunicorn_thrift/config.py
+++ b/gunicorn_thrift/config.py
@@ -92,6 +92,23 @@ class ClientConnected(Setting):
         """
 
 
+class TDecodeExceptionRaised(Setting):
+    name = "on_tdecode_exception"
+    section = "Server Hooks"
+    validator = validate_callable(1)
+    type = six.callable
+
+    def on_tdecode_exception(err):
+        pass
+
+    default = staticmethod(on_tdecode_exception)
+    desc = """\
+        Called if tdecode exception is raised
+
+        The callable needs to accept one variable for the exception raised.
+        """
+
+
 class ClientConnectClosed(Setting):
     name = "post_connect_closed"
     section = "Server Hooks"

--- a/gunicorn_thrift/thriftpy_gevent_worker.py
+++ b/gunicorn_thrift/thriftpy_gevent_worker.py
@@ -28,6 +28,7 @@ from thriftpy.transport import TSocket
 from thriftpy.transport import TTransportException
 from thriftpy.protocol.exc import TProtocolException
 from thriftpy.protocol.cybin import ProtocolError
+from thriftpy.thrift import TDecodeException
 
 from gunicorn.errors import AppImportError
 from gunicorn.workers.ggevent import GeventWorker
@@ -175,6 +176,9 @@ class GeventThriftPyWorker(GeventWorker, ProcessorMixin):
             self.log.warning(
                 "Protocol error, is client(%s) correct? %s", addr, err
                 )
+        except TDecodeException as err:
+            self.log.exception('%r: %r', addr, err)
+            self.cfg.on_tdecode_exception(err)
         except socket.timeout:
             self.log.warning('Client timeout: %r', addr)
         except socket.error as e:

--- a/gunicorn_thrift/thriftpy_sync_worker.py
+++ b/gunicorn_thrift/thriftpy_sync_worker.py
@@ -12,6 +12,7 @@ except ImportError:
 
 from thriftpy.transport import TSocket
 from thriftpy.transport import TTransportException
+from thriftpy.thrift import TDecodeException
 
 from gunicorn.errors import AppImportError
 from gunicorn.workers.sync import SyncWorker
@@ -68,6 +69,9 @@ class SyncThriftPyWorker(SyncWorker, ProcessorMixin):
                     self.notify()
             except TTransportException:
                 pass
+        except TDecodeException as err:
+            self.log.exception('%r: %r', addr, err)
+            self.cfg.on_tdecode_exception(err)
         except socket.timeout:
             self.log.warning('Client timeout: %r', addr)
         except socket.error as e:


### PR DESCRIPTION
This hook is tested on gevent thriftpy worker.