### PR TITLE
Two fixes to thriftpy_gevent_worker.py for py3 compat

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@ Thrift app and worker for gunicorn! Hence, a multi-process python thrift server!
 ## Supported Platforms
 
 * Python 2.7, all worker classes
-* Python 3.2+, `thriftpy_sync` worker class (neither gevent nor code generated
-  using the Thrift toolkit are supported on Python 3)
+* Python 3.2+, `thriftpy_sync` and `thriftpy_gevent` worker classes (code generated
+  using the Thrift toolkit is not supported on Python 3)
 
 ## Examples
 
@@ -100,10 +100,10 @@ There are 4 types of workers available.
 note: If you want to use `thriftpy_sync` or `thriftpy_gevent`, make sure the following:
 
 * Version of `thriftpy` should be higher than `0.1.10`.
-* `--thrift-protocol-factory` should be set to either:  
+* `--thrift-protocol-factory` should be set to either:
     1. `thriftpy.protocol:TCyBinaryProtocolFactory` or
     1. `thriftpy.protocol:TBinaryProtocolFactory`
-* `--thrift-transport-factory` should be set to either:  
+* `--thrift-transport-factory` should be set to either:
     1. `thriftpy.transport:TCyBufferedTransportFactory` or
     1. `thriftpy.transport:TBufferedTransportFactory`
 
@@ -112,9 +112,9 @@ note: If you want to use `thriftpy_sync` or `thriftpy_gevent`, make sure the fol
 
 The transport factory to use for handling connections.
 
-Parameter: `--thrift-transport-factory`  
-Config file: `thrift_transport_factory`  
-Default 2.7: `thrift.transport.TTransport:TBufferedTransportFactory`  
+Parameter: `--thrift-transport-factory`
+Config file: `thrift_transport_factory`
+Default 2.7: `thrift.transport.TTransport:TBufferedTransportFactory`
 Default 3.2+: `thriftpy.transport:TBufferedTransportFactory`
 
 
@@ -122,17 +122,17 @@ Default 3.2+: `thriftpy.transport:TBufferedTransportFactory`
 
 The protocol factory to use for parsing requests.
 
-Parameter: `--thrift-protocol-factory`  
-Config file: `thrift_protocol_factory`  
-Default 2.7: `thrift.protocol.TBinaryProtocol:TBinaryProtocolAcceleratedFactory`  
+Parameter: `--thrift-protocol-factory`
+Config file: `thrift_protocol_factory`
+Default 2.7: `thrift.protocol.TBinaryProtocol:TBinaryProtocolAcceleratedFactory`
 Default 3.2+: `thriftpy.protocol:TBinaryProtocolFactory`
 
 ### Client timeout
 
 Seconds to timeout a client if it is silent after this duration.
 
-Parameter: `--thrift-client-timeout`  
-Config file: `thrift_client_timeout`  
+Parameter: `--thrift-client-timeout`
+Config file: `thrift_client_timeout`
 Default: `None` (Never time out a client)
 
 ### Gevent check interval
@@ -140,9 +140,9 @@ Default: `None` (Never time out a client)
 This config will run a seperate thread to detect gevent ioloop block every
 specified seconds.
 
-Parameter: `--gevent-check-interval`  
-Config file: `gevent_check_interval`  
-Default: 0  
+Parameter: `--gevent-check-interval`
+Config file: `gevent_check_interval`
+Default: 0
 
 Note: DONOT USE this if not running gevent worker.
 

--- a/gunicorn_thrift/thriftpy_gevent_worker.py
+++ b/gunicorn_thrift/thriftpy_gevent_worker.py
@@ -4,10 +4,15 @@
 import sys
 import time
 import errno
-import thread
 import socket
 import logging
 import traceback
+
+try:
+    import thread
+except ImportError:
+    # Python 3
+    import _thread as thread
 
 try:
     import gevent
@@ -97,7 +102,7 @@ class GeventThriftPyWorker(GeventWorker, ProcessorMixin):
 
         return super(GeventThriftPyWorker, self).init_process()
 
-    def _greenlet_switch_tracer(self, what, (origin, target)):
+    def _greenlet_switch_tracer(self, what, where):
         """Callback method executed on every greenlet switch.
 
         The worker arranges for this method to be called on every greenlet
@@ -107,6 +112,7 @@ class GeventThriftPyWorker(GeventWorker, ProcessorMixin):
         # Increment the counter to indicate that a switch took place.
         # This will periodically be reset to zero by the monitoring thread,
         # so we don't need to worry about it growing without bound.
+        origin, target = where
         self._active_greenlet = target
         self._greenlet_switch_counter += 1
 

--- a/requirements_py27.txt
+++ b/requirements_py27.txt
@@ -1,5 +1,5 @@
 setproctitle==1.1.10
-gevent>=1.0.1,<1.2
+gevent>=1.0.1
 gunicorn>=19.3.0,<19.4.0
 wsgiref==0.1.2
 thrift>=0.9.0

--- a/requirements_py3x.txt
+++ b/requirements_py3x.txt
@@ -1,3 +1,4 @@
 setproctitle==1.1.10
+gevent>=1.2,<1.3
 gunicorn>=19.4.0
 thriftpy>=0.1.15

--- a/test_requirements_py27.txt
+++ b/test_requirements_py27.txt
@@ -1,4 +1,4 @@
 pytest
 pytest-cov
-gevent==1.0.1
+gevent==1.2.2
 thrift==0.9.3

--- a/test_requirements_py3x.txt
+++ b/test_requirements_py3x.txt
@@ -1,2 +1,4 @@
 pytest
 pytest-cov
+gevent==1.2.2
+thrift==0.9.3

--- a/tests/test_thriftpy_gevent_worker.py
+++ b/tests/test_thriftpy_gevent_worker.py
@@ -9,10 +9,8 @@ import pytest
 from thriftpy.transport import TTransportException
 
 from . import AboutToShutDownException, make_client
-from .six import requires_py27
 
 
-@requires_py27
 class TestThriftpyGeventWorker:
     def test_connectivity(self, PingServiceThriftpy,
                           pingpong_thriftpy_server_gevent):


### PR DESCRIPTION
First fix: Wrap low-level "thread" import with try-except to fallback to
the Python 3-specific "_thread" module.

Second fix: Remove now-obsolete tuple-unpacking syntax from
_greenlet_switch_tracer method signature, and replace with
vesion-agnostic tuple unpack in method body.