### PR TITLE
remove six dependency and bump gunicorn / gevent versions

### DIFF
--- a/gunicorn_thrift/config.py
+++ b/gunicorn_thrift/config.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 
 
-from gunicorn import six
 from gunicorn.config import Setting, validate_string, validate_pos_int,\
     WorkerClass, validate_callable, validate_bool, validate_dict
 
@@ -59,7 +58,7 @@ class WorkerTerm(Setting):
     name = "worker_term"
     section = "Server Hooks"
     validator = validate_callable(1)
-    type = six.callable
+    type = callable
 
     def worker_term(worker):
         pass
@@ -78,7 +77,7 @@ class ClientConnected(Setting):
     name = "on_connected"
     section = "Server Hooks"
     validator = validate_callable(2)
-    type = six.callable
+    type = callable
 
     def on_connected(worker, addr):
         pass
@@ -96,7 +95,7 @@ class TDecodeExceptionRaised(Setting):
     name = "on_tdecode_exception"
     section = "Server Hooks"
     validator = validate_callable(1)
-    type = six.callable
+    type = callable
 
     def on_tdecode_exception(err):
         pass
@@ -113,7 +112,7 @@ class ClientConnectClosed(Setting):
     name = "post_connect_closed"
     section = "Server Hooks"
     validator = validate_callable(1)
-    type = six.callable
+    type = callable
 
     def post_connect_closed(worker):
         pass

--- a/requirements_py3x.txt
+++ b/requirements_py3x.txt
@@ -1,4 +1,4 @@
 setproctitle==1.1.10
-gevent>=1.4,<1.5
-gunicorn==19.9.0
+gevent>=1.4,<24
+gunicorn>=19.9.0,<22
 thriftpy2>=0.4.0

--- a/test_requirements_py3x.txt
+++ b/test_requirements_py3x.txt
@@ -1,4 +1,4 @@
 pytest
 pytest-cov
-gevent>=1.4,<1.5
+gevent>=1.4,<24
 thrift>=0.9.3


### PR DESCRIPTION
close #74

`callable` is only missing in Python 3.0 and 3.1, and since these versions are very rare to use, we can just remove the `six` dependency and use the builtin `callable` function.